### PR TITLE
Support for GraalVM 25 Native Image

### DIFF
--- a/web/src/main/resources/META-INF/native-image/io.agentscope/agentscope-runtime-web/reachability-metadata.json
+++ b/web/src/main/resources/META-INF/native-image/io.agentscope/agentscope-runtime-web/reachability-metadata.json
@@ -1,0 +1,84 @@
+{
+  "reflection": [
+    {
+      "type": "com.alibaba.dashscope.aigc.generation.GenerationOutput$Choice",
+      "fields": [
+        {
+          "name": "finishReason"
+        },
+        {
+          "name": "index"
+        },
+        {
+          "name": "message"
+        }
+      ],
+      "unsafeAllocated": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.alibaba.dashscope.aigc.generation.GenerationOutputTokenDetails",
+      "fields": [
+        {
+          "name": "reasoningTokens"
+        }
+      ],
+      "unsafeAllocated": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.alibaba.dashscope.aigc.generation.GenerationUsage",
+      "fields": [
+        {
+          "name": "inputTokens"
+        },
+        {
+          "name": "outputTokens"
+        },
+        {
+          "name": "outputTokensDetails"
+        },
+        {
+          "name": "promptTokensDetails"
+        },
+        {
+          "name": "totalTokens"
+        }
+      ],
+      "unsafeAllocated": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.alibaba.dashscope.aigc.generation.GenerationUsage$PromptTokensDetails",
+      "fields": [
+        {
+          "name": "cachedTokens"
+        }
+      ],
+      "unsafeAllocated": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    }
+  ],
+  "resources": [
+  ]
+}


### PR DESCRIPTION
Support native image compiling for agentscope-runtime-java. We found some reflection information is missing from native image agent collecting, so an extra configuration file is provided. 
Be noted, it is for GraalVM 25. Earlier GraalVM version needs the old reflection-config.json file.