### PR TITLE
feat: add application.yaml to configure api key

### DIFF
--- a/examples/simple_sandbox_tool_example/src/main/resources/application.yaml
+++ b/examples/simple_sandbox_tool_example/src/main/resources/application.yaml
@@ -4,7 +4,5 @@ spring:
 
 server:
   port: 8080
-  servlet:
-    context-path: /api
 
 DASHSCOPE_API_KEY: "your-api-key"


### PR DESCRIPTION
In the current `examples/simple_sandbox_tool_example`, the default api includes the `/api` prefix, but it missing the `resources/application.yaml`, causing request errors in the example. 

This PR adds the `application.yaml` file to configure the `context-path` and `DASHSCOPE_API_KEY`.