### PR TITLE
fix: use the sessionId of sandbox instead of random string, so we can…

### DIFF
--- a/sandbox-core/src/main/java/io/agentscope/runtime/sandbox/manager/SandboxService.java
+++ b/sandbox-core/src/main/java/io/agentscope/runtime/sandbox/manager/SandboxService.java
@@ -159,7 +159,7 @@ public class SandboxService implements AutoCloseable {
             logger.info("Docker image is ready: {}", imageName);
         }
 
-        String sessionId = RandomStringGenerator.generateRandomString(22);
+        String sessionId = sandbox.getSessionId();
         String currentDir = System.getProperty("user.dir");
         String mountDir = currentDir + "/" + default_mount_dir + "/" + sessionId;
 


### PR DESCRIPTION
`
// 1. Set the sessionId of sandbox
BaseSandbox baseSandbox = new BaseSandbox(sandboxService, userId, sessionId);

// 2. Find mounted files by sessionId
@GetMapping("/file/list/{sessionId}")
public ResponseEntity<List<String>> listDocuments(@PathVariable String sessionId) {
    try {
        Path workspacePath = Paths.get(System.getProperty("user.dir"), "sessions_mount_dir", sessionId);
        if (!Files.exists(workspacePath)) {
            return ResponseEntity.ok(List.of());
        }
        List<String> files = Files.list(workspacePath)
            .filter(Files::isRegularFile)
            .map(p -> p.getFileName().toString())
            .collect(Collectors.toList());
        return ResponseEntity.ok(files);
    } catch (Exception e) {
        return ResponseEntity.internalServerError().build();
    }
}
`