### PR TITLE
Fix: correct ManagerConfig.Builder method name from clientConfig to clientStarter

### DIFF
--- a/examples/browser_use_fullstack_runtime/backend/src/main/java/io/agentscope/browser/BrowserAgentApplication.java
+++ b/examples/browser_use_fullstack_runtime/backend/src/main/java/io/agentscope/browser/BrowserAgentApplication.java
@@ -70,9 +70,9 @@ public class BrowserAgentApplication {
     @Bean
     public SandboxService sandboxService() {
         logger.info("Creating SandboxService bean");
-        BaseClientStarter clientConfig = DockerClientStarter.builder().build();
+        BaseClientStarter clientStarter = DockerClientStarter.builder().build();
         ManagerConfig managerConfig = ManagerConfig.builder()
-                .clientConfig(clientConfig)
+                .clientStarter(clientStarter)
                 .build();
         SandboxService sandboxService = new SandboxService(managerConfig);
         sandboxService.start();


### PR DESCRIPTION
## Summary
- Fixed compilation error in `BrowserAgentApplication.java` where the wrong method name was called on `ManagerConfig.Builder`
- Changed `.clientConfig()` to `.clientStarter()` to match the actual method name defined in `ManagerConfig.Builder` class

## Changes
- `examples/browser_use_fullstack_runtime/backend/src/main/java/io/agentscope/browser/BrowserAgentApplication.java`
  - Renamed variable `clientConfig` → `clientStarter` for consistency
  - Fixed method call `.clientConfig(clientConfig)` → `.clientStarter(clientStarter)`

## Root Cause
The `ManagerConfig.Builder` class defines the method as `clientStarter(BaseClientStarter)`, but the code was calling a non-existent `clientConfig()` method.

## Test
- ✅ `mvn compile` - BUILD SUCCESS
- ✅ `mvn spotless:apply` - Code formatted
