### PR TITLE
fix: update examples to use clientStarter and fix BrowserSandbox lazy init

### DIFF
--- a/examples/browser_use_fullstack_runtime/backend/src/main/java/io/agentscope/browser/BrowserAgentApplication.java
+++ b/examples/browser_use_fullstack_runtime/backend/src/main/java/io/agentscope/browser/BrowserAgentApplication.java
@@ -70,9 +70,9 @@ public class BrowserAgentApplication {
     @Bean
     public SandboxService sandboxService() {
         logger.info("Creating SandboxService bean");
-        BaseClientStarter clientConfig = DockerClientStarter.builder().build();
+        BaseClientStarter clientStarter = DockerClientStarter.builder().build();
         ManagerConfig managerConfig = ManagerConfig.builder()
-                .clientConfig(clientConfig)
+                .clientStarter(clientStarter)
                 .build();
         SandboxService sandboxService = new SandboxService(managerConfig);
         sandboxService.start();

--- a/examples/simple_agent_use_examples/custom_sandbox_example/src/main/java/io/agentscope/Main.java
+++ b/examples/simple_agent_use_examples/custom_sandbox_example/src/main/java/io/agentscope/Main.java
@@ -25,9 +25,9 @@ import io.agentscope.runtime.sandbox.manager.client.container.docker.DockerClien
 
 public class Main {
     public static void main(String[] args) {
-        BaseClientStarter clientConfig = DockerClientStarter.builder().build();
+        BaseClientStarter clientStarter = DockerClientStarter.builder().build();
         ManagerConfig managerConfig = ManagerConfig.builder()
-                .clientConfig(clientConfig)
+                .clientStarter(clientStarter)
                 .build();
         SandboxService sandboxService = new SandboxService(managerConfig);
         sandboxService.start();

--- a/examples/simple_sandbox_tool_example/src/main/java/com/example/agentscope/config/AgentConfig.java
+++ b/examples/simple_sandbox_tool_example/src/main/java/com/example/agentscope/config/AgentConfig.java
@@ -68,9 +68,9 @@ public class AgentConfig {
      */
     @Bean
     public SandboxService sandboxService() {
-        BaseClientStarter clientConfig = DockerClientStarter.builder().build();
+        BaseClientStarter clientStarter = DockerClientStarter.builder().build();
         ManagerConfig managerConfig = ManagerConfig.builder()
-                .clientConfig(clientConfig)
+                .clientStarter(clientStarter)
                 .build();
 
         SandboxService service = new SandboxService(managerConfig);
@@ -92,9 +92,13 @@ public class AgentConfig {
         try {
             BrowserSandbox browserSandbox = new BrowserSandbox(sandboxService, "agent-user", "agent-session");
             toolkit.registerTool(ToolkitInit.BrowserNavigateTool(browserSandbox));
+            // getInfo() triggers lazy initialization (container creation)
+            // getDesktopUrl() bypasses it, so we must initialize first
+            browserSandbox.getInfo();
             String desktopUrl = browserSandbox.getDesktopUrl();
             System.out.println("GUI Desktop URL: " + desktopUrl);
-        } catch (Exception ignored) {
+        } catch (Exception exception) {
+            exception.printStackTrace();
         }
         return toolkit;
     }

--- a/examples/structured_sandbox_tool_example/src/main/java/com/example/agentscope/SandboxStructuredExample.java
+++ b/examples/structured_sandbox_tool_example/src/main/java/com/example/agentscope/SandboxStructuredExample.java
@@ -39,9 +39,9 @@ public class SandboxStructuredExample {
 
     public static void main(String[] args) throws Exception {
 
-        BaseClientStarter clientConfig = DockerClientStarter.builder().build();
+        BaseClientStarter clientStarter = DockerClientStarter.builder().build();
         ManagerConfig managerConfig = ManagerConfig.builder()
-                .clientConfig(clientConfig)
+                .clientStarter(clientStarter)
                 .build();
 
         SandboxService service = new SandboxService(managerConfig);
@@ -49,8 +49,11 @@ public class SandboxStructuredExample {
 
         Toolkit toolkit = new Toolkit();
         try {
-            BrowserSandbox browserSandbox = new BrowserSandbox(service, "agent-user", "agent-sessopn");
+            BrowserSandbox browserSandbox = new BrowserSandbox(service, "agent-user", "agent-session");
             toolkit.registerTool(ToolkitInit.BrowserNavigateTool(browserSandbox));
+            // getInfo() triggers lazy initialization (container creation)
+            // getDesktopUrl() bypasses it, so we must initialize first
+            browserSandbox.getInfo();
             String desktopUrl = browserSandbox.getDesktopUrl();
             System.out.println("GUI Desktop URL: " + desktopUrl);
         } catch (Exception ignored) {


### PR DESCRIPTION
## Summary

Fix compilation errors and runtime exceptions in example projects caused by the sandbox module refactoring (commit 12b25af).

## Changes

### 1. Rename `clientConfig` → `clientStarter` (4 files)
The `ManagerConfig.builder()` method was renamed from `.clientConfig()` to `.clientStarter()` in the core module, but the examples were not updated accordingly.

**Affected files:**
- `simple_sandbox_tool_example/AgentConfig.java`
- `structured_sandbox_tool_example/SandboxStructuredExample.java`
- `custom_sandbox_example/Main.java`
- `browser_use_fullstack_runtime/BrowserAgentApplication.java`

### 2. Fix BrowserSandbox lazy initialization (2 files)
`BrowserSandbox.getDesktopUrl()` calls `GuiMixin.getDesktopUrl()` which directly invokes `managerApi.getInfo()` bypassing the lazy initialization in `Sandbox.getInfo()`. This causes a `RuntimeException: Sandbox null is not healthy` when the container hasn't been created yet.

**Fix:** Add `browserSandbox.getInfo()` before `getDesktopUrl()` to trigger container creation.

### 3. Fix typo
`agent-sessopn` → `agent-session` in `SandboxStructuredExample.java`

## Testing
- All 7 example projects compile successfully
- `simple_sandbox_tool_example`: Spring Boot started, Docker container created, VNC URL accessible
- `browser_use_fullstack_runtime`: Spring Boot started on port 8080
- `custom_sandbox_example`: SandboxService started and exited normally